### PR TITLE
fix pe_ratio column

### DIFF
--- a/lib/yahoo_finance.rb
+++ b/lib/yahoo_finance.rb
@@ -81,7 +81,7 @@ end
      :price_per_sales => "p5",
      :price_per_book => "p6",
      :ex_dividend_date => "q",
-     :pe_ratio => "p5",
+     :pe_ratio => "r0",
      :dividend_pay_date => "r1",
      :pe_ratio_realtime => "r2",
      :peg_ratio => "r5",


### PR DESCRIPTION
After attempting to use this gem in an app, it became clear that the P/E Ratio it was getting was incorrect.  I googled around to find Yahoo documentation on the available columns and was not able to find it on their site.  I did, however, find documentation on several other sites that say that pe_ratio should be column 'r0'.  After the change, the data I'm getting appears to be correct.

It's a simple one-line change - it would be great if you could merge it in.
