### PR TITLE
actualized rakefile and gemspec a little bit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+gem 'rake', '~> 0.9.0'
+gem 'bundler'

--- a/Rakefile
+++ b/Rakefile
@@ -1,24 +1,11 @@
-require 'rake'
-require 'rake/gempackagetask'
-require 'fileutils'
-require 'lib/yahoo_finance'
-include FileUtils
+require 'rake/testtask'
 
-spec = Gem::Specification.new do |s|
-  s.name = "yahoo-finance"
-  s.version = "0.0.2"
-  s.author = "Herval Freire"
-  s.email = "herval@hervalicio.us"
-  s.homepage = "http://hervalicio.us/blog"
-  s.platform = Gem::Platform::RUBY
-  s.summary = "A wrapper to Yahoo! Finance market data (quotes and exchange rates) feed"
-  s.files = FileList["{bin,lib}/**/*"].to_a
-  s.require_path = "lib"
-  s.autorequire = "yahoo_finance"
-  s.has_rdoc = false
-  s.extra_rdoc_files = ["README", "HISTORY"]
-end
+require 'bundler/setup'
 
-Rake::GemPackageTask.new(spec) do |pkg|
-  pkg.need_tar = false
+Bundler::GemHelper.install_tasks
+
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/*test.rb']
+  t.verbose = true
 end

--- a/yahoo-finance.gemspec
+++ b/yahoo-finance.gemspec
@@ -1,6 +1,9 @@
+$LOAD_PATH << '.'
+require 'lib/yahoo_finance'
+
 spec = Gem::Specification.new do |s|
   s.name = "yahoo-finance"
-  s.version = "0.1.0"
+  s.version = YahooFinance::VERSION
   s.author = "Herval Freire"
   s.email = "herval@hervalicio.us"
   s.homepage = "http://hervalicio.us/blog"


### PR DESCRIPTION
Some improvements over current rakefile and packaging:
- prevents "ERROR: 'rake/gempackagetask' is obsolete and no longer supported. Use 'rubygems/packagetask' instead." from happening, this leads to halting all rake tasks
- bundler support and Gemfile
- cleaned up rakefile
- packaging tasks delegated to Bundler::GemHelper
- version to packaging task not hardcoded anymore
- rake test
- removed useless require statements

Motivation and notes on packaging: http://yehudakatz.com/2010/04/02/using-gemspecs-as-intended/
