### PR TITLE
Fix yahoo CSV API url (404)

### DIFF
--- a/lib/yahoo_finance.rb
+++ b/lib/yahoo_finance.rb
@@ -140,7 +140,7 @@ end
   
   def self.read_symbols(symb_str, cols)
      columns = "#{cols.map {|col| COLUMNS[col] }.join('')}"
-     conn = open("http://finance.yahoo.com/d/quotes.csv?s=#{URI.escape(symb_str)}&f=#{columns}")
+     conn = open("http://download.finance.yahoo.com/d/quotes.csv?s=#{URI.escape(symb_str)}&f=#{columns}")
      CSV.parse(conn.read, :headers => cols)
   end
 


### PR DESCRIPTION
The Yahoo CSV API URL is not working any more (returning 404)
I've fixed this by changing the domain name.
