### PR TITLE
Add rubygems.org source to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+source 'https://rubygems.org'
 gem "rake"
 gem "bundler"
 gem "json"


### PR DESCRIPTION
Add `source 'https://rubygems.org'` to Gemfile.

[Gemfiles require at least one gem source, in the form of the URL for a RubyGems server.](http://bundler.io/gemfile.html)