### PR TITLE
Remove invalid columns_array keys in quotes method

### DIFF
--- a/lib/yahoo-finance.rb
+++ b/lib/yahoo-finance.rb
@@ -115,6 +115,9 @@ module YahooFinance
       :symbol, :last_trade_price, :last_trade_date,
       :change, :previous_close], options = {})
 
+      # remove invalid keys
+      columns_array.reject! { |c| !COLUMNS.key?(c) }
+
       options[:raw] ||= true
       ret = []
       symbols_array.each_slice(SYMBOLS_PER_REQUEST) do |symbols|


### PR DESCRIPTION
Remove invalid user-supplied keys passed to columns_array parameter of the quotes method. Fix #35