### PR TITLE
fix historical quotes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 gem "rake"
 gem "bundler"
 gem "json"
+gem "nokogiri"
+gem 'test-unit', :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,13 @@ GEM
   remote: https://rubygems.org/
   specs:
     json (1.8.2)
+    mini_portile2 (2.1.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    power_assert (0.2.6)
     rake (10.4.2)
+    test-unit (3.1.5)
+      power_assert
 
 PLATFORMS
   ruby
@@ -10,7 +16,9 @@ PLATFORMS
 DEPENDENCIES
   bundler
   json
+  nokogiri
   rake
+  test-unit
 
 BUNDLED WITH
-   1.10.6
+   1.13.6

--- a/README.md
+++ b/README.md
@@ -166,9 +166,12 @@ data = yahoo_client.quotes(yahoo_client.symbols_by_market('us', 'nyse'), [:ask, 
 
 ### Getting historical quotes
 
-Here you can specify a date range and a symbol, and retrieve historical data for it. 
-The last parameter (options) can include, besides the "raw" option, a "period" option.
-The period can be specified as :daily, :monthly, :weekly or :dividends_only
+Retrieve historical data for a specific symbol (i.e. `AAPL`).
+
+The last parameter (options) can include:
+- `period`: can be specified as `:daily`, `:monthly`, `:weekly`
+- `start_date`: the date from which historical quotes should be fetched (the parameter value should respond to `to_time`) (default: yesterday)
+- `end_date`: the date up to which historical quotes should be fetched (the parameter value should respond to `to_time`) (default: today)
 
 ```ruby
 yahoo_client = YahooFinance::Client.new
@@ -186,7 +189,7 @@ or
 
 ``` ruby
 yahoo_client = YahooFinance::Client.new
-data = yahoo_client.historical_quotes("AAPL", { raw: false, period: :monthly })
+data = yahoo_client.historical_quotes("AAPL", { period: :monthly })
 ```
 
 ### Getting splits

--- a/Rakefile
+++ b/Rakefile
@@ -9,3 +9,7 @@ Rake::TestTask.new do |t|
   t.test_files = FileList['test/*test.rb']
   t.verbose = true
 end
+
+task :console do
+  exec "irb -r yahoo-finance -I ./lib"
+end

--- a/lib/yahoo-finance.rb
+++ b/lib/yahoo-finance.rb
@@ -204,6 +204,7 @@ module YahooFinance
       doc = Nokogiri::HTML(open(url))
       rows = doc.xpath("//table")[1].css('tr')
 
+      return [] if rows.empty?
       cols = rows[0].css('th').to_a
       trade_date_col = cols.index { |c| c.text == 'Date' }
       open_col = cols.index { |c| c.text == 'Open' }

--- a/lib/yahoo-finance.rb
+++ b/lib/yahoo-finance.rb
@@ -216,7 +216,7 @@ module YahooFinance
 
       rows.drop(0).inject([]) do |data, row|
         divs = row.css('td')
-        if divs[1] && !divs[1].text.include?('Dividend') #Ignore this row in the table
+        if divs[1] && !divs[1].text.include?('Dividend') && !divs[1].text.include?('Stock Split') #Ignore these rows in the table
           data << OpenStruct.new({
             'symbol': symbol,
             'date': Date.parse(divs[trade_date_col]).to_s,

--- a/lib/yahoo-finance.rb
+++ b/lib/yahoo-finance.rb
@@ -167,7 +167,7 @@ module YahooFinance
                  end
       current_date = start_date.to_time.to_i
       data = []
-      while Time.at(current_date).to_datetime < end_date
+      while Time.at(current_date) < end_date
         params[:period1] = current_date
         current_end_date = [current_date + time_from_days(days_per_page), end_date.to_time.to_i].min
         params[:period2] = current_end_date
@@ -235,7 +235,7 @@ module YahooFinance
         if divs[1] && !divs[1].text.include?('Dividend') && !divs[1].text.include?('Stock Split') #Ignore these rows in the table
           data << OpenStruct.new({
             'symbol': symbol,
-            'date': Date.parse(divs[trade_date_col]).to_s,
+            'trade_date': Date.parse(divs[trade_date_col]).to_s,
             'open': divs[open_col].text.to_f,
             'high': divs[high_col].text.to_f,
             'low': divs[low_col].text.to_f,

--- a/test/yahoo_finance_test.rb
+++ b/test/yahoo_finance_test.rb
@@ -25,7 +25,7 @@ class YahooFinanceTest < Test::Unit::TestCase
     ycl = YahooFinance::Client.new
     quote = ycl.quote('AAPL', columns)
     columns.each do |col|
-      assert quote.send(col), 'quote.#{col} was nil #{quote}'
+      assert quote.public_send(col), 'quote.#{col} was nil #{quote}'
     end
     assert !quote.symbol.nil?, ':symbol name is always present'
   end
@@ -54,10 +54,10 @@ class YahooFinanceTest < Test::Unit::TestCase
 
   def test_historical_quotes
     ycl = YahooFinance::Client.new
-    q = ycl.historical_quotes('MSFT', raw: false, period: :daily, start_date: days_ago(40))
-    
-    [:trade_date, :open, :high, :low, :close, :volume, :adjusted_close].each do |col|
-      assert q.first.send(col)
+    q = ycl.historical_quotes('MSFT', period: :daily, start_date: days_ago(40))
+
+    [:date, :open, :high, :low, :close, :volume, :adjusted_close].each do |col|
+      assert q.first.public_send(col)
     end
   end
 

--- a/test/yahoo_finance_test.rb
+++ b/test/yahoo_finance_test.rb
@@ -56,7 +56,7 @@ class YahooFinanceTest < Test::Unit::TestCase
     ycl = YahooFinance::Client.new
     q = ycl.historical_quotes('MSFT', period: :daily, start_date: days_ago(40))
 
-    [:date, :open, :high, :low, :close, :volume, :adjusted_close].each do |col|
+    [:trade_date, :open, :high, :low, :close, :volume, :adjusted_close].each do |col|
       assert q.first.public_send(col)
     end
   end


### PR DESCRIPTION
closes https://github.com/herval/yahoo-finance/issues/42

Fixed historical quotes following the snippet on https://github.com/herval/yahoo-finance/issues/42#issuecomment-308550444.

I changed `trade_date` to `date`. If that's a problem, I can change it back.