### PR TITLE
fix historical data

### DIFF
--- a/lib/yahoo-finance.rb
+++ b/lib/yahoo-finance.rb
@@ -218,7 +218,7 @@ module YahooFinance
 
     def read_historical(symbol, url)
       doc = Nokogiri::HTML(open(url))
-      rows = doc.xpath("//table")[1].css('tr')
+      rows = doc.xpath("//table")[0].css('tr')
 
       return [] if rows.empty?
       cols = rows[0].css('th').to_a


### PR DESCRIPTION
relates to #52

Here is a quick fix for the quote function. Apparently, Yahoo changed the layout of their historical data page... After this fix, I can get historical prices again.

Sorry to the users of this gem but until the gem uses v7 API, any change to the page might break the code.